### PR TITLE
signIn custom page 제거, RootLayout 모든 페이지 적용

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,11 +1,14 @@
 import '@/styles/globals.css'
 import type { AppProps } from 'next/app'
 import { SessionProvider } from 'next-auth/react'
+import RootLayout from '@/components/Layout'
 
 export default function App({ Component, pageProps: { session, ...pageProps } }: AppProps) {
   return (
     <SessionProvider session={session}>
-      <Component {...pageProps} />
+      <RootLayout>
+        <Component {...pageProps} />
+      </RootLayout>
     </SessionProvider>
   )
 }

--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -25,9 +25,9 @@ export const authOptions: NextAuthOptions = {
       userId = res._id
       return true
     }
-  },
-  pages: {
-    signIn: '/auth/signin'
   }
+  // pages: {
+  //   signIn: '/auth/signin'
+  // }
 }
 export default NextAuth(authOptions)

--- a/src/pages/auth/signin/index.tsx
+++ b/src/pages/auth/signin/index.tsx
@@ -23,6 +23,7 @@ export default function SignPage({ providers }: Props) {
     </div>
   )
 }
+
 export async function getServerSideProps(context: GetServerSidePropsContext) {
   const session = await getServerSession(context.req, context.res, authOptions)
   if (session) {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,12 +1,9 @@
-import RootLayout from '@/components/Layout'
 import LandingPage from '../components/landingPage'
 
 export default function Home() {
   return (
     <div className="bg-slate-100">
-      <RootLayout>
-        <LandingPage />
-      </RootLayout>
+      <LandingPage />
     </div>
   )
 }


### PR DESCRIPTION
# signIn custom page 제거했습니다.

nextAuth에서 제공하는 기본 로그인 화면을 그대로 사용하도록 해뒀습니다!

sign in페이지를 커스텀하게 꾸미고 싶을 떄 꾸밀 수 있도록 주속으로 남겨뒀습니다.

# RootLayout 모든 페이지 적용

모든 페이지에 Header와 Footer가 포함된 Layout이 적용되도록 컴포넌트 위치를 변경했습니다.
